### PR TITLE
Surface favorite-team sync errors in the UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,13 +23,14 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState(getDefaultDate());
   const [favoriteTeamId, setFavoriteTeam] = useState(() => getFavoriteTeamId());
   const [user, setUser] = useState(null);
+  const [syncError, setSyncError] = useState(null);
   const prevUidRef = useRef(null);
 
   function handleSetFavorite(teamId) {
     setFavoriteTeamId(teamId);
     setFavoriteTeam(teamId);
     if (user) {
-      setCloudFavoriteTeamId(user.uid, teamId);
+      setCloudFavoriteTeamId(user.uid, teamId, (err) => setSyncError(err.message));
     }
   }
 
@@ -43,7 +44,7 @@ export default function App() {
     const prevUid = prevUidRef.current;
 
     if (uid && uid !== prevUid) {
-      reconcileFavoriteTeamOnSignIn(uid).then(setFavoriteTeam);
+      reconcileFavoriteTeamOnSignIn(uid, (err) => setSyncError(err.message)).then(setFavoriteTeam);
     } else if (!uid && prevUid) {
       clearFavoriteTeamId();
       Promise.resolve(null).then(setFavoriteTeam);
@@ -78,6 +79,16 @@ export default function App() {
             </nav>
             {isFirebaseConfigured && (
               <AuthControl user={user} onSignIn={signInWithGoogle} onSignOut={signOutUser} />
+            )}
+            {syncError && (
+              <button
+                className="sync-error-badge"
+                onClick={() => alert(`Favorite team sync failed:\n\n${syncError}`)}
+                title="Favorite team sync failed — tap for details"
+                aria-label="Favorite team sync failed"
+              >
+                ⚠
+              </button>
             )}
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -187,6 +187,22 @@ body {
   border-color: var(--gold-dim);
 }
 
+.sync-error-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-elevated);
+  border: 1px solid #c94040;
+  color: #e07070;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
 .auth-control {
   position: relative;
 }

--- a/src/utils/favorites.js
+++ b/src/utils/favorites.js
@@ -35,7 +35,7 @@ export function clearFavoriteTeamId() {
 // Reconciles localStorage with the signed-in user's Realtime Database record.
 // Cloud value wins if one was already saved; otherwise the local value (if any)
 // is migrated up so it isn't silently lost on first sign-in.
-export async function reconcileFavoriteTeamOnSignIn(uid) {
+export async function reconcileFavoriteTeamOnSignIn(uid, onError) {
   if (!isFirebaseConfigured || !db || !uid) return getFavoriteTeamId();
 
   try {
@@ -55,15 +55,17 @@ export async function reconcileFavoriteTeamOnSignIn(uid) {
     return localTeamId;
   } catch (err) {
     console.warn('Failed to sync favorite team with the Realtime Database.', err);
+    onError?.(err);
     return getFavoriteTeamId();
   }
 }
 
-export async function setCloudFavoriteTeamId(uid, teamId) {
+export async function setCloudFavoriteTeamId(uid, teamId, onError) {
   if (!isFirebaseConfigured || !db || !uid) return;
   try {
     await set(ref(db, favoritePath(uid)), teamId);
   } catch (err) {
     console.warn('Failed to save favorite team to the Realtime Database.', err);
+    onError?.(err);
   }
 }


### PR DESCRIPTION
## Summary
- All favorite-team sync failures (Realtime Database read/write errors) were only logged via `console.warn`, which is undiagnosable on devices without accessible dev tools (e.g. iPad Safari).
- Adds a small tappable warning badge (⚠) next to the auth icon in the header, shown only when a sync error occurs. Tapping it shows the actual error message via `alert()` so the real failure reason is visible on any device.
- `reconcileFavoriteTeamOnSignIn` and `setCloudFavoriteTeamId` now accept an optional `onError` callback; existing call sites without it behave exactly as before (no behavior change for the no-op case).

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` shows no new errors (same 9 pre-existing errors)
- [ ] User to retest on iPad: if sync still fails, tap the warning badge to read the actual error and report it back


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8W35R7QB4oDhfce9oEWmB)_