### PR TITLE
Surface Google sign-in failures, including silent redirect-flow no-ops

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,19 +23,19 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState(getDefaultDate());
   const [favoriteTeamId, setFavoriteTeam] = useState(() => getFavoriteTeamId());
   const [user, setUser] = useState(null);
-  const [syncError, setSyncError] = useState(null);
+  const [errorNotice, setErrorNotice] = useState(null);
   const prevUidRef = useRef(null);
 
   function handleSetFavorite(teamId) {
     setFavoriteTeamId(teamId);
     setFavoriteTeam(teamId);
     if (user) {
-      setCloudFavoriteTeamId(user.uid, teamId, (err) => setSyncError(err.message));
+      setCloudFavoriteTeamId(user.uid, teamId, (err) => setErrorNotice(`Favorite team sync failed: ${err.message}`));
     }
   }
 
   useEffect(() => {
-    completeRedirectSignIn();
+    completeRedirectSignIn(setErrorNotice);
     return watchAuthState(setUser);
   }, []);
 
@@ -44,7 +44,7 @@ export default function App() {
     const prevUid = prevUidRef.current;
 
     if (uid && uid !== prevUid) {
-      reconcileFavoriteTeamOnSignIn(uid, (err) => setSyncError(err.message)).then(setFavoriteTeam);
+      reconcileFavoriteTeamOnSignIn(uid, (err) => setErrorNotice(`Favorite team sync failed: ${err.message}`)).then(setFavoriteTeam);
     } else if (!uid && prevUid) {
       clearFavoriteTeamId();
       Promise.resolve(null).then(setFavoriteTeam);
@@ -78,14 +78,18 @@ export default function App() {
               <button className={`nav-btn ${tab === 'news'      ? 'active' : ''}`} onClick={() => setTab('news')}>News</button>
             </nav>
             {isFirebaseConfigured && (
-              <AuthControl user={user} onSignIn={signInWithGoogle} onSignOut={signOutUser} />
+              <AuthControl
+                user={user}
+                onSignIn={() => signInWithGoogle(setErrorNotice)}
+                onSignOut={signOutUser}
+              />
             )}
-            {syncError && (
+            {errorNotice && (
               <button
-                className="sync-error-badge"
-                onClick={() => alert(`Favorite team sync failed:\n\n${syncError}`)}
-                title="Favorite team sync failed — tap for details"
-                aria-label="Favorite team sync failed"
+                className="error-badge"
+                onClick={() => alert(errorNotice)}
+                title="Something went wrong — tap for details"
+                aria-label="Error details"
               >
                 ⚠
               </button>

--- a/src/index.css
+++ b/src/index.css
@@ -187,7 +187,7 @@ body {
   border-color: var(--gold-dim);
 }
 
-.sync-error-badge {
+.error-badge {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -17,6 +17,29 @@ function shouldUseRedirect() {
   return isIOS || isSafari || isInAppBrowser;
 }
 
+// Set right before signInWithRedirect navigates away, and checked when the
+// app reloads after returning from Google. Lets us tell "redirect flow
+// attempted but getRedirectResult silently came back empty" apart from a
+// normal first page load with no error to report.
+const REDIRECT_PENDING_KEY = 'navhawk_auth_redirect_pending';
+
+function clearRedirectPending() {
+  try {
+    sessionStorage.removeItem(REDIRECT_PENDING_KEY);
+  } catch {
+    // sessionStorage unavailable — nothing to clear
+  }
+}
+
+async function redirectToGoogle() {
+  try {
+    sessionStorage.setItem(REDIRECT_PENDING_KEY, '1');
+  } catch {
+    // sessionStorage unavailable — the silent-failure check on return just won't fire
+  }
+  await signInWithRedirect(auth, googleProvider);
+}
+
 export function watchAuthState(callback) {
   if (!isFirebaseConfigured || !auth) {
     callback(null);
@@ -25,31 +48,55 @@ export function watchAuthState(callback) {
   return onAuthStateChanged(auth, callback);
 }
 
-export async function completeRedirectSignIn() {
+export async function completeRedirectSignIn(onError) {
   if (!isFirebaseConfigured || !auth) return null;
+  let wasPending = false;
+  try {
+    wasPending = sessionStorage.getItem(REDIRECT_PENDING_KEY) === '1';
+  } catch {
+    // sessionStorage unavailable — skip the silent-failure check below
+  }
+
   try {
     const result = await getRedirectResult(auth);
-    return result ? result.user : null;
+    clearRedirectPending();
+    if (result) return result.user;
+    if (wasPending) {
+      onError?.(
+        "Sign-in didn't complete and no error was reported. On iPad/Safari this is usually caused by " +
+        "'Prevent Cross-Site Tracking' blocking sign-in storage during the redirect — try turning that off " +
+        "in Settings > Safari, or sign in from Chrome instead."
+      );
+    }
+    return null;
   } catch (err) {
+    clearRedirectPending();
     console.warn('Google redirect sign-in failed.', err);
+    onError?.(`Google sign-in failed: ${err.message}`);
     return null;
   }
 }
 
-export async function signInWithGoogle() {
+export async function signInWithGoogle(onError) {
   if (!isFirebaseConfigured || !auth || !googleProvider) return;
   try {
     if (shouldUseRedirect()) {
-      await signInWithRedirect(auth, googleProvider);
+      await redirectToGoogle();
     } else {
       await signInWithPopup(auth, googleProvider);
     }
   } catch (err) {
     // Popup blocked or unsupported in this environment — fall back to redirect.
     if (err?.code === 'auth/popup-blocked' || err?.code === 'auth/operation-not-supported-in-this-environment') {
-      await signInWithRedirect(auth, googleProvider);
+      try {
+        await redirectToGoogle();
+      } catch (redirectErr) {
+        console.warn('Google sign-in failed.', redirectErr);
+        onError?.(`Google sign-in failed: ${redirectErr.message}`);
+      }
     } else {
       console.warn('Google sign-in failed.', err);
+      onError?.(`Google sign-in failed: ${err.message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- On iPad/Safari, the Google sign-in redirect flow can fail silently — Safari's cross-site tracking prevention can block the storage continuity `signInWithRedirect`/`getRedirectResult` depend on, so the app never throws an error and never transitions to a signed-in state. This matches the reported symptom: tapping "G" repeatedly re-runs the login flow with no visible change.
- Track when a redirect sign-in was attempted (via `sessionStorage`) so a `null` result from `getRedirectResult` after returning from Google can be told apart from a normal page load, and surface it with an actionable message instead of only `console.warn`.
- Also surface any thrown errors from `signInWithGoogle`/`completeRedirectSignIn`, reusing the same tappable warning badge already added for favorite-team sync failures (generalized from `syncError` to `errorNotice` so both error sources share one UI element).

## Test plan
- [x] `npm run lint` — no new errors in changed files
- [x] `npm run build` — succeeds
- [ ] User to retest sign-in on iPad: if it still doesn't complete, the warning badge should now appear with a specific message (either a thrown Firebase error, or the new ITP-pointing message) instead of nothing happening


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8W35R7QB4oDhfce9oEWmB)_