### PR TITLE
Prefer popup over redirect for Google sign-in outside in-app browsers

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -7,14 +7,16 @@ import {
 } from 'firebase/auth';
 import { auth, googleProvider, isFirebaseConfigured } from './firebase';
 
-// Popup sign-in is unreliable in mobile Safari and in-app browsers, so those
-// environments use a redirect flow instead.
+// Redirect needs a real window.open, which in-app browsers (Instagram, Facebook,
+// Line) don't support — those fall back to a redirect flow. Everywhere else,
+// including standalone Safari/iOS, popup is preferred: redirect's full-page
+// round trip through the authDomain relies on storage continuity that Safari's
+// cross-site tracking prevention can silently break (confirmed in production —
+// see the ITP message in completeRedirectSignIn below).
 function shouldUseRedirect() {
   const ua = navigator.userAgent || '';
-  const isIOS = /iPad|iPhone|iPod/.test(ua);
-  const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|Chrome/.test(ua);
   const isInAppBrowser = /FBAN|FBAV|Instagram|Line\//.test(ua);
-  return isIOS || isSafari || isInAppBrowser;
+  return isInAppBrowser;
 }
 
 // Set right before signInWithRedirect navigates away, and checked when the


### PR DESCRIPTION
## Summary
- The previous PR's new error-visibility surfaced the exact root cause on the user's iPad: "Sign-in didn't complete and no error was reported" — confirming `getRedirectResult` was silently returning null after the redirect round trip, consistent with Safari's cross-site tracking prevention blocking the storage continuity that flow depends on.
- `shouldUseRedirect()` previously sent all iOS/Safari traffic through redirect based on generic, unverified guidance from when the feature was first built — not because of any observed popup failure.
- Flip the heuristic: use `signInWithPopup` everywhere a real `window.open` is available (including standalone Safari/iOS), and reserve `signInWithRedirect` for in-app browsers (Instagram, Facebook, Line) that can't pop a real window. If a popup does get blocked, it still falls back to redirect — which is now itself error-visible from the prior PR.

## Test plan
- [x] `npm run build` — succeeds
- [ ] User to retest sign-in on iPad: should now open a popup instead of redirecting, and complete without the ITP warning


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8W35R7QB4oDhfce9oEWmB)_