### PR TITLE
Stop surfacing cancelled-popup-request as a sign-in failure

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -79,8 +79,15 @@ export async function completeRedirectSignIn(onError) {
   }
 }
 
+// Guards against a second tap starting a new popup before the first one
+// resolves — without this, Firebase cancels the first popup's promise with
+// auth/cancelled-popup-request, which would otherwise surface as a bogus
+// error even though the second (superseding) attempt succeeds.
+let signInInFlight = false;
+
 export async function signInWithGoogle(onError) {
-  if (!isFirebaseConfigured || !auth || !googleProvider) return;
+  if (!isFirebaseConfigured || !auth || !googleProvider || signInInFlight) return;
+  signInInFlight = true;
   try {
     if (shouldUseRedirect()) {
       await redirectToGoogle();
@@ -88,8 +95,10 @@ export async function signInWithGoogle(onError) {
       await signInWithPopup(auth, googleProvider);
     }
   } catch (err) {
-    // Popup blocked or unsupported in this environment — fall back to redirect.
-    if (err?.code === 'auth/popup-blocked' || err?.code === 'auth/operation-not-supported-in-this-environment') {
+    if (err?.code === 'auth/cancelled-popup-request' || err?.code === 'auth/popup-closed-by-user') {
+      // Expected: a duplicate sign-in attempt got cancelled, or the user
+      // dismissed the popup themselves. Not a real failure.
+    } else if (err?.code === 'auth/popup-blocked' || err?.code === 'auth/operation-not-supported-in-this-environment') {
       try {
         await redirectToGoogle();
       } catch (redirectErr) {
@@ -100,6 +109,8 @@ export async function signInWithGoogle(onError) {
       console.warn('Google sign-in failed.', err);
       onError?.(`Google sign-in failed: ${err.message}`);
     }
+  } finally {
+    signInInFlight = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- After switching to popup sign-in, the user saw "Google sign-in failed: Firebase: Error (auth/cancelled-popup-request)" — but their favorite team data was already in the database, meaning sign-in actually succeeded.
- Root cause: a second tap before the first popup resolved causes Firebase to cancel the first popup's promise with `auth/cancelled-popup-request`, while the second (superseding) popup completes normally. The cancelled promise's rejection was being reported as a real failure.
- Fix: guard `signInWithGoogle` against concurrent invocations so a second tap is a no-op while one is in flight, and treat `auth/cancelled-popup-request` / `auth/popup-closed-by-user` as expected outcomes rather than errors (in case they still occur from some other path).

## Test plan
- [x] `npm run build` — succeeds
- [ ] User to retest sign-in on iPad, including a deliberate double-tap on the sign-in icon, to confirm no spurious error appears


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8W35R7QB4oDhfce9oEWmB)_